### PR TITLE
Call Jest and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 script:
  - yarn test:unit
  - yarn electron:build
- - jest --coverage --coverageReporters=text-lcov | coveralls
+ - yarn run test:unit --coverage --coverageReporters=text-lcov | ./node_modules/.bin/coveralls


### PR DESCRIPTION
## Explanation of work done and why:

Stop Travis-CI tests from failing.

Jest should be called by `vue-cli-service test:unit` or `yarn test:unit`.

Coveralls is located in `node_modules/.bin/`.  This could be a `package.json` `scripts` entry, but if run manually, then Coveralls needs some parameters setup.

## How to (manually) test:

~~I'm not sure.  Perhaps just run it.~~

Check out [Travis-CI Pull Requests](https://travis-ci.org/nerdtribe/mr-binge/pull_requests).  Specifically this [PR Build](https://travis-ci.org/nerdtribe/mr-binge/builds/592719417).

Or, better yet, the bottom of this PR.

## Checklist:
- [ ] **Closes** N/A
- [ ] **Tests written**
- [ ] **Code linted**
- [ ] **Errors handled**
- [ ] **Version number bumped**
