### PR TITLE
Upgrade set-value due to vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,7 +2154,7 @@ cache-base@^1.0.1:
     get-value "^2.0.6"
     has-value "^1.0.0"
     isobject "^3.0.1"
-    set-value "^2.0.0"
+    set-value "^2.0.1"
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"


### PR DESCRIPTION
CVE-2019-10747 More information
high severity
Vulnerable versions: < 2.0.1
Patched version: 2.0.1
set-value is vulnerable to Prototype Pollution in versions before 2.0.1 and version 3.0.0. The function mixin-deep could be tricked into adding or modifying properties of Object.prototype using any of the constructor, prototype and proto payloads.