### PR TITLE
Add media button (#40 First!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr-binge",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr-binge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/MediaComponent.vue
+++ b/src/components/MediaComponent.vue
@@ -14,6 +14,18 @@
         :id="n"
       />
     </v-col>
+    <v-btn
+      color="primary"
+      dark
+      absolute
+      fixed
+      bottom
+      right
+      fab
+      class="add-btn"
+    >
+      <v-icon>mdi-plus</v-icon>
+    </v-btn>
   </v-row>
 </template>
 
@@ -31,3 +43,9 @@ export default Vue.extend({
   }
 });
 </script>
+
+<style lang="scss">
+.add-btn {
+  margin: 0 25px 50px 0;
+}
+</style>


### PR DESCRIPTION
## Explanation of work done and why:
<!-- Scope and areas affected, related PRs etc. -->
<!-- Who wants this functionality, and why -->
GUI button that will trigger searchbar in future PR

## How to (manually) test:
<!-- (acceptance criteria) -->
1. Fetch `git fetch && git checkout add-media-button origin/add-media-button`
2. Serve `yarn electron:serve`
3. Observe the blue add media button is in the lower right corner for both the movie and tv views..

## Checklist:
Fixes: #10 
- [-] **Tests written**
- [x] **Code linted**
- [x] **Errors handled**
- [x] **Version number bumped**
