### PR TITLE
Search preview dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr-binge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/TheSearchDrawerComponent.vue
+++ b/src/components/TheSearchDrawerComponent.vue
@@ -31,13 +31,15 @@
             </v-img>
             <v-card-actions>
               <v-btn text
-                     small>
+                     small
+                     @click.stop="showTmdbSearchDialog = !showTmdbSearchDialog">
                 View
               </v-btn>
               <v-spacer />
               <v-btn text
                      small
-                     color="primary">
+                     color="primary"
+                     @click.once.prevent="add('id')">
                 Add to Library
               </v-btn>
             </v-card-actions>
@@ -45,14 +47,19 @@
         </v-col>
       </v-row>
     </v-container>
+    <TheSearchPreviewDialogComponent v-model="showTmdbSearchDialog" />
   </v-navigation-drawer>
 </template>
 
 <script>
 import Vue from "vue";
+import TheSearchPreviewDialogComponent from "./TheSearchPreviewDialogComponent";
 
 export default Vue.extend({
   name: "TheSearchDrawerComponent",
+  components: {
+    TheSearchPreviewDialogComponent,
+  },
   props: {
     value: {
       type: Boolean,
@@ -65,8 +72,8 @@ export default Vue.extend({
       { title: "Frozen II", year: "2019", src: "https://image.tmdb.org/t/p/w300_and_h450_bestv2/pjeMs3yqRmFL3giJy4PMXWZTTPa.jpg" },
       { title: "Avengers: Infinity War", year: "2018", src: "https://image.tmdb.org/t/p/w600_and_h900_bestv2/7WsyChQLEftFiDOVTGkv3hFpyyt.jpg" },
     ],
+    showTmdbSearchDialog: false,
   }),
-
   computed: {
     drawer: {
       get() {
@@ -76,6 +83,12 @@ export default Vue.extend({
         this.$emit("input", newValue);
       }
     }
+  },
+  methods: {
+    add(id) {
+      console.log(`Firing ${id}`);
+      this.dialog = false;
+    },
   },
 });
 </script>

--- a/src/components/TheSearchPreviewDialogComponent.vue
+++ b/src/components/TheSearchPreviewDialogComponent.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="dialog"
             persistent
             max-width="75%">
-    <v-card>
+    <v-card class="ma-0">
       <v-card-title class="headline">
         Frozen II <span class="caption mt-2 ml-2"> (2019)</span>
       </v-card-title>

--- a/src/components/TheSearchPreviewDialogComponent.vue
+++ b/src/components/TheSearchPreviewDialogComponent.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-dialog v-model="dialog"
+            persistent
+            max-width="75%">
+    <v-card>
+      <v-card-title class="headline">
+        Frozen II <span class="caption mt-2 ml-2"> (2019)</span>
+      </v-card-title>
+      <v-toolbar flat
+                 class="mb-2">
+        <v-rating
+          :value="3"
+          background-color="white"
+          color="yellow accent-4"
+          dense
+          half-increments
+          readonly
+          size="24" />
+        <v-spacer />
+        <v-tooltip bottom>
+          <template v-slot:activator="{ on }">
+            <v-progress-circular :value="70"
+                                 :size="55"
+                                 :width="8"
+                                 v-on="on">
+              70%
+            </v-progress-circular>
+          </template>
+          <span>Rating via 188 votes.</span>
+        </v-tooltip>
+      </v-toolbar>
+      <v-card-text class="d-flex align-center flex-column">
+        Elsa, Anna, Kristoff and Olaf head far into the forest to learn the truth about an ancient mystery of their kingdom.
+        <div class="pa-4">
+         <youtube video-id="Zi4LMpSDccc" />
+        </div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text
+               @click="dialog = false">
+          Close
+        </v-btn>
+        <v-btn text
+               @click.once.prevent="add('id')">
+          Add to Library
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "TheSearchPreviewDialogComponent",
+  props: {
+    value: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+  },
+  data: () => ({ }),
+  computed: {
+    dialog: {
+      get() {
+        return this.value;
+      },
+      set(newValue) {
+        this.$emit("input", newValue);
+      }
+    }
+  },
+  methods: {
+    add(id) {
+      console.log(`Firing ${id}`);
+      this.dialog = false;
+    },
+  },
+});
+</script>

--- a/src/components/TheSearchPreviewDialogComponent.vue
+++ b/src/components/TheSearchPreviewDialogComponent.vue
@@ -32,11 +32,11 @@
       <v-card-text class="d-flex align-center flex-column">
         Elsa, Anna, Kristoff and Olaf head far into the forest to learn the truth about an ancient mystery of their kingdom.
         <div class="pa-4">
-         <youtube video-id="Zi4LMpSDccc" />
+          <youtube video-id="Zi4LMpSDccc" />
         </div>
       </v-card-text>
       <v-card-actions>
-        <v-spacer></v-spacer>
+        <v-spacer />
         <v-btn text
                @click="dialog = false">
           Close

--- a/tests/unit/TheSearchPreviewDialogComponent.spec.js
+++ b/tests/unit/TheSearchPreviewDialogComponent.spec.js
@@ -3,14 +3,17 @@ import Vue from "vue";
 import Vuex from "vuex";
 import VueRouter from "vue-router";
 import Vuetify from "vuetify";
-import TheSearchDrawerComponent from "@/components/TheSearchDrawerComponent";
+import TheSearchPreviewDialogComponent from "@/components/TheSearchPreviewDialogComponent";
 
-describe("TheSearchDrawerComponent.vue", () => {
+// Ignore youtube-embed as its tested via cypress
+Vue.config.ignoredElements = ["youtube"];
+
+describe("TheSearchPreviewDialogComponent.vue", () => {
   const localVue = createLocalVue();
   localVue.use(VueRouter);
   const router = new VueRouter();
 
-  const shallowMountFunction = options => shallowMount(TheSearchDrawerComponent, {
+  const shallowMountFunction = options => shallowMount(TheSearchPreviewDialogComponent, {
     Vuetify,
     localVue,
     router,
@@ -25,12 +28,6 @@ describe("TheSearchDrawerComponent.vue", () => {
   test("render", () => {
     const wrapper = shallowMountFunction({});
     expect(wrapper.isVueInstance()).toBe(true);
-  });
-
-  test("dialog", () => {
-    const wrapper = shallowMountFunction({});
-    wrapper.vm.drawer = true;
-    expect(wrapper.vm.drawer).toBeTruthy();
   });
 
   test("add", () => {


### PR DESCRIPTION
## Explanation of work done and why:
<!-- Scope and areas affected, related PRs etc. -->
<!-- Who wants this functionality, and why -->
This PR adds the dialog view for when a user is previewing a search result item. The _Add To Library_ buttons on both the search drawer and the preview dialog are stubbed to a console log at the moment.
![image](https://user-images.githubusercontent.com/8315447/76530649-66023680-644a-11ea-81a8-1e02931d537a.png)

## How to (manually) test:
<!-- (acceptance criteria) -->
1. Navigate to the search TMDB sidebar.
2. Click on _Add To Library_ button and observe a console log.
3. Click on _View_ button and observe the dialog that contains [Title, year, star rating, % rating, description, youtube preview and action buttons]
4. Click on _Add To Library_ button and observe a console log and the dialog closes.
5. Reopen via _View_ button and click _Close_ button and the dialog closes.
6. Run unit tests verify 100% Code Coverage. `yarn test:unit --coverage`

## Checklist:
- [-] **Closes** <!-- #issue-number(s) -->
- [x] **Tests written**
- [x] **Code linted**
- [x] **Errors handled**
- [x] **Version number bumped**
